### PR TITLE
fix  LayoutConstraints warning

### DIFF
--- a/EmptyDataSet-Swift/Sources/EmptyDataSetView.swift
+++ b/EmptyDataSet-Swift/Sources/EmptyDataSetView.swift
@@ -254,8 +254,9 @@ public class EmptyDataSetView: UIView {
                 detailLabel.isHidden = false
                 subviewStrings.append("detailLabel")
                 views[subviewStrings.last!] = detailLabel
-
-                contentView.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "H:|-(padding)-[detailLabel(>=0)]-(padding)-|", options: [], metrics: metrics, views: views))
+                let labelWidth = width - CGFloat(padding) * 2.0
+                contentView.addConstraint(NSLayoutConstraint.init(item: titleLabel, attribute: .centerX, relatedBy: .equal, toItem: contentView, attribute: .centerX, multiplier: 1.0, constant: 0.0))
+                contentView.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "[titleLabel(\(labelWidth))]", options: [], metrics: metrics, views: views))
             } else {
                 detailLabel.isHidden = true
             }


### PR DESCRIPTION
 [LayoutConstraints] Unable to simultaneously satisfy constraints.
	Probably at least one of the constraints in the following list is one you don't want.
	Try this:
		(1) look at each constraint and try to figure out which you don't expect;
		(2) find the code that added the unwanted constraint or constraints and fix it.
	(Note: If you're seeing NSAutoresizingMaskLayoutConstraints that you don't understand, refer to the documentation for the UIView property translatesAutoresizingMaskIntoConstraints)
(
    "<NSAutoresizingMaskLayoutConstraint:0x6000009f0b90 h=--& v=--& EmptyDataSet_Swift.EmptyDataSetView:0x7fb5aa00e600.width == 0   (active)>",
    "<NSLayoutConstraint:0x6000009f0320 UIView:0x7fb5aa077fb0.centerX == EmptyDataSet_Swift.EmptyDataSetView:0x7fb5aa00e600.centerX   (active)>",
    "<NSLayoutConstraint:0x6000009f0370 H:|-(0)-[UIView:0x7fb5aa077fb0]   (active, names: '|':EmptyDataSet_Swift.EmptyDataSetView:0x7fb5aa00e600 )>",
    "<NSLayoutConstraint:0x6000009f0640 H:|-(26)-[empty set title]   (active, names: empty set title:0x7fb5aa01c200, '|':UIView:0x7fb5aa077fb0 )>",
    "<NSLayoutConstraint:0x6000009f0730 H:[empty set title]-(26)-|   (active, names: empty set title:0x7fb5aa01c200, '|':UIView:0x7fb5aa077fb0 )>"
)

Will attempt to recover by breaking constraint
<NSLayoutConstraint:0x6000009f0730 H:[empty set title]-(26)-|   (active, names: empty set title:0x7fb5aa01c200, '|':UIView:0x7fb5aa077fb0 )>

Make a symbolic breakpoint at UIViewAlertForUnsatisfiableConstraints to catch this in the debugger.
The methods in the UIConstraintBasedLayoutDebugging category on UIView listed in <UIKitCore/UIView.h> may also be helpful.